### PR TITLE
broken symlinks = bad time for du

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ function du (dir, options, callback) {
     options  = {}
   }
 
-  fs.stat(dir = path.resolve(dir), function (err, stat) {
+  fs.lstat(dir = path.resolve(dir), function (err, stat) {
     if (err) return callback(err)
 
     if (!stat) return callback(null, 0)


### PR DESCRIPTION
Produces an error like so:

```
Error: ENOENT, no such file or directory '/path/to/symlink'
```

This now adds size of symlink to total.

Another option would be to should ignore symlinks or perhaps even try reading the target, and fail silently if it can't.
