### PR TITLE
Added options.disk to do block sizing

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ Also comes with a `dujs` command if installed with `npm install du -g`, just in 
 
 ## options
 
-An optional `options` object may be passed as the second argument. Currently there is only one option, a `'filter'` function that is passed a full file path and is expected to return a truthy/falsy value to indicate whether the file is included in size calculations.
+An optional `options` object may be passed as the second argument. Currently there is only two options,
+a `'filter'` function that is passed a full file path and is expected to return a truthy/falsy value to indicate whether the file is included in size calculations
+and a `disk` option. If disk is true, then block sizing is used when calculating the size. (get's you closer to real du numbers).
 
 ```js
 du(

--- a/index.js
+++ b/index.js
@@ -15,8 +15,10 @@ function du (dir, options, callback) {
 
     if (!stat) return callback(null, 0)
 
+    var size = options.disk ? (512 * stat.blocks) : stat.size
+
     if (!stat.isDirectory())
-      return callback(null, !options.filter || options.filter(dir) ? stat.size : 0)
+      return callback(null, !options.filter || options.filter(dir) ? size : 0)
 
     fs.readdir(dir, function (err, list) {
       if (err) return callback(err)
@@ -33,7 +35,7 @@ function du (dir, options, callback) {
                 err
               , sizes && sizes.reduce(function (p, s) {
                   return p + s
-                }, stat.size)
+                }, size)
             )
           }
       )


### PR DESCRIPTION
I noticed that when using this module, I was getting way different numbers than that of the native `du` command. By adding a config for `disk` it will produce a size closer to that of the on disk size and it will be much closer to the actual output of `du`.
